### PR TITLE
Add charge boost

### DIFF
--- a/drivers/power/supply/Kconfig
+++ b/drivers/power/supply/Kconfig
@@ -521,6 +521,13 @@ config NX30P6093
 	  usb_psy to disable CC detection on the event of any water/debris
 	  detected at USBIN.
 
+config CHARGE_BOOST
+	bool "Charge boost"
+	default n
+	depends on CPU_INPUT_BOOST
+	help
+	  Boosts the CPU when the power supply is plugged in and charging or fully charged.
+
 source "drivers/power/supply/qcom/Kconfig"
 
 endif # POWER_SUPPLY


### PR DESCRIPTION
This boosts the CPU frequency when the battery is plugged in and charging using the cpu_input_boost_kick_max function in cpu_input_boost.
This may be useful for users who are not concerned about saving power when their phone is plugged in for a performance boost.

echo Y > /sys/module/qpnp_fg_gen3/parameters/charge_boost_enabled (To enable)
echo N > /sys/module/qpnp_fg_gen3/parameters/charge_boost_enabled (To disable)